### PR TITLE
Add RSS feed

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -6,6 +6,8 @@ execute:
 
 website:
   title: "Sol @ Utrecht University Library"
+  site-url: https://utrechtuniversity.github.io/sol/
+  description: "Sol is a microblog maintained by Research Data Services at Utrecht University Library"
   navbar:
     background: "#FFCD00"
     search: true
@@ -14,6 +16,8 @@ website:
         text: Home
       - about.qmd
       - archive.qmd
+      - icon: rss
+        href: index.xml
   page-footer: 
     background: black
     left: © CC-BY 4.0
@@ -28,6 +32,3 @@ format:
       light: [cosmo, styles/theme-light.scss]
       dark: [cosmo, styles/theme-dark.scss]
     toc: true
-
-
-

--- a/index.qmd
+++ b/index.qmd
@@ -4,5 +4,6 @@ listing:
   type: default # or `default` or `table`; each type has its own set of yaml options to include
   sort: "date desc" # can also sort on more than one field
   categories: true # allows you to sort posts by assigned categories 
+  feed: true
 ---
 


### PR DESCRIPTION
Quarto makes it incredibly easy to create an RSS feed. I think it is a nice and simple addition to Sol. So here some proposed edits to make this happen. Instructions from Quarto about this are here: https://quarto.org/docs/websites/website-blog.html#rss-feed